### PR TITLE
Updated version of java.classpath dependency.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,5 +2,5 @@
   :description "Clojure tools is a set of clojure utilities pulled out of Conjure."
   :dependencies [[commons-lang/commons-lang "2.5"]
                  [org.clojure/clojure "1.4.0"]
-                 [org.clojure/java.classpath "0.2.0"]
+                 [org.clojure/java.classpath "0.2.1"]
                  [org.clojure/tools.logging "0.2.3"]])


### PR DESCRIPTION
The previous version doesn't support paths with spaces on Windows.
