### PR TITLE
Identify directories with encoded characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ classes
 .lein-failures
 .pmd
 target/
+.lein-env

--- a/project.clj
+++ b/project.clj
@@ -3,4 +3,5 @@
   :dependencies [[commons-lang/commons-lang "2.5"]
                  [org.clojure/clojure "1.4.0"]
                  [org.clojure/java.classpath "0.2.1"]
-                 [org.clojure/tools.logging "0.2.3"]])
+                 [org.clojure/tools.logging "0.2.3"]
+                 [ring/ring-codec "1.1.0"]])

--- a/src/clojure/tools/loading_utils.clj
+++ b/src/clojure/tools/loading_utils.clj
@@ -6,7 +6,8 @@
             [clojure.string :as clojure-str-utils]
             [clojure.tools.file-utils :as file-utils]
             [clojure.tools.logging :as logging]
-            [clojure.tools.string-utils :as string-utils]))
+            [clojure.tools.string-utils :as string-utils]
+            [ring.util.codec :refer [url-decode]]))
 
 (defn
 #^{ :doc "Gets the system class loader" }
@@ -23,10 +24,11 @@
 
 (defn
   classpath-directories []
-  (filter file-utils/is-directory?
-    (if-let [classpath (user-classpath-var?)]
-      (map #(File. %) (.split (var-get classpath) (path-separator)))
-      (classpath/classpath))))
+  (filter
+   file-utils/is-directory?
+   (if-let [classpath (user-classpath-var?)]
+     (map #(File. (url-decode %)) (.split (var-get classpath) (path-separator)))
+     (classpath/classpath))))
 
 (defn
   #^{ :doc "Returns true if the given file is a jar fiel. False otherwise, even if the is file check causes an


### PR DESCRIPTION
is-directory? fails if any path component has URL encoded characters.  Even a "space" in the path name will break the "is-directory?" comparison

Found this issue as drift could not find my migrations.

Hopefully it will not offend if I push forks of drift and Clojure-tools to clojars.